### PR TITLE
rebuild with 12.6.4

### DIFF
--- a/ios/manifest
+++ b/ios/manifest
@@ -2,9 +2,10 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.0
+version: 2.1.0
 apiversion: 2
-architectures: armv7 arm64 i386 x86_64
+architectures: arm64 x86_64
+mac: false
 description: titanium-image-filters
 author: Hans Knoechel
 license: MIT

--- a/ios/titanium.xcconfig
+++ b/ios/titanium.xcconfig
@@ -4,12 +4,11 @@
 // OF YOUR TITANIUM SDK YOU'RE BUILDING FOR
 //
 //
-TITANIUM_SDK_VERSION = 9.0.1.GA
-
+TITANIUM_SDK_VERSION = 12.6.4.GA
 
 //
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
 TITANIUM_SDK = /Users/$(USER)/Library/Application Support/Titanium/mobilesdk/osx/$(TITANIUM_SDK_VERSION)
 HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/include"
-FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"
+FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"


### PR DESCRIPTION
Version 2.0.0 wasn't released but I still updated the version to 2.1.0.
Works on ARM Macs
[ti.imagefilters-iphone-2.1.0.zip](https://github.com/user-attachments/files/19928796/ti.imagefilters-iphone-2.1.0.zip)